### PR TITLE
fix: Add t & k to the variation of the ObjInfo msg part

### DIFF
--- a/source/soccerserver.rst
+++ b/source/soccerserver.rst
@@ -189,7 +189,7 @@ The following table shows the protocol for client version 14 or later.
 | |               (*ObjName* *Distance* *Direction* *DistChange* *DirChange* *BodyFacingDir* *HeadFacingDir*               |
 |                       [*PointDir*] [t] [k]])                                                                             |
 | |               \| (*ObjName* *Distance* *Direction* *DistChange* *DirChange* [*PointDir*] [{t|k}])                      |
-| |               \| (*ObjName* *Distance* *Direction*)                                                                    |
+| |               \| (*ObjName* *Distance* *Direction* [t] [k])                                                            |
 | |               \| (*ObjName* *Diretion*)                                                                                |
 | |    *ObjName* ::= (p ["*TeamName*" [*UniformNumber* [goalie]]])                                                         |
 | |               \| (b)                                                                                                   |


### PR DESCRIPTION
During development of the client it was discovered, that t and k also
appear in See messages, when there is only direction and distance
specified for an object (in this case, player).